### PR TITLE
Example client flow for PSS

### DIFF
--- a/contents/pss.rst
+++ b/contents/pss.rst
@@ -81,3 +81,14 @@ Protocols
 ^^^^^^^^^
 
 A framework is also in place for making ``devp2p`` protocols available using ``pss`` connections. This feature is only available using lower-level integration, and documentation is out of scope of this document.
+
+Example client flow
+-------------------
+
+This example presents a sequence of API calls made by a client to have two users interact with each other.
+
+1. First, both peers need to know each other public key, and a common ``Topic`` over which they will communicate. The client needs to call ``pss_getPublicKey`` to retrieve a node's public key, and can use ``pss_stringToTopic`` to create a ``Topic`` from an UTF-8 string.
+2. Once both public keys and the topic are known, the client must call ``pss_setPeerPublicKey`` providing the other peer's public key, the ``Topic`` and overlay ``Address`` to use for routing in order to retrieve a key identifier later used to send messages.
+3. In order to be notified when messages are received, the client must first create a subscription by calling ``pss_subscribe`` with the ``receive`` string and the ``Topic`` as arguments, in order to retrieve a subscription identifier.
+4. Provided the subscription identifier, the client can listen to notifications emitted with the ``pss_subscription`` method, and check if the ``subscription`` provided in the notification ``params`` matches the relevant identifier.
+5. Now ready to receive messages, the client can send messages to the other peer by calling the ``pss_sendAsym`` method with the peer's key identifier, ``Topic`` and hex-encoded message payload.

--- a/contents/pss.rst
+++ b/contents/pss.rst
@@ -87,8 +87,8 @@ Example client flow
 
 This example presents a sequence of API calls made by a client to have two users interact with each other.
 
-1. First, both peers need to know each other public key, and a common ``Topic`` over which they will communicate. The client needs to call ``pss_getPublicKey`` to retrieve a node's public key, and can use ``pss_stringToTopic`` to create a ``Topic`` from an UTF-8 string.
-2. Once both public keys and the topic are known, the client must call ``pss_setPeerPublicKey`` providing the other peer's public key, the ``Topic`` and overlay ``Address`` to use for routing in order to retrieve a key identifier later used to send messages.
-3. In order to be notified when messages are received, the client must first create a subscription by calling ``pss_subscribe`` with the ``receive`` string and the ``Topic`` as arguments, in order to retrieve a subscription identifier.
+1. First, both peers need to know each other public key, and a common topic over which they will communicate. The client needs to call ``pss.getPublicKey()`` to retrieve a node's public key, and can use ``pss.stringToTopic(name)`` to create a topic from the UTF-8 ``name`` string provided.
+2. Once both public keys and the topic are known, the client must call ``pss.setPeerPublicKey(publickey, topic, address)`` providing the other peer's public key, the agreed-upon topic and overlay address to use for routing in order to retrieve a key identifier later used to send messages.
+3. To be notified when messages are received, the client must first create a subscription by calling ``pss.subscribe("receive", topic)`` in order to retrieve a subscription identifier.
 4. Provided the subscription identifier, the client can listen to notifications emitted with the ``pss_subscription`` method, and check if the ``subscription`` provided in the notification ``params`` matches the relevant identifier.
-5. Now ready to receive messages, the client can send messages to the other peer by calling the ``pss_sendAsym`` method with the peer's key identifier, ``Topic`` and hex-encoded message payload.
+5. Now ready to receive messages, the client can send messages to the other peer by calling the ``pss.sendAsym(publickey, topic, message)`` method with the peer's key identifier, topic and message payload.


### PR DESCRIPTION
@dleonard00 here is a first stab at describing a flow the client can implement to provide communication between 2 peers using PSS, please don't hesitate to alter anything you see fit.

I don't know about Sphinx and the usual practices for these docs, but one thing that could be useful would be to add HTML anchors to each API method in the PSS docs, so they could be linked to directly in this example or other docs.
I also noticed that there are 2 APIs documented in PSS that seem at odds with the rest: `pss.GetSymmetricAddressHint(topic, symkeyid)` and `pss.GetAsymmetricAddressHint(topic, publickey)` have an uppercase leading `G` while all other APIs start with a lowercase character, I think it's a leftover from the Go API.

